### PR TITLE
Feat entity associated to itself

### DIFF
--- a/src/Bitmap/Association.php
+++ b/src/Bitmap/Association.php
@@ -49,14 +49,17 @@ abstract class Association
     /**
      * Return the list of join clauses from the class managed by the mapper $left
      *
-     * @param Mapper $left
+     * @param string $name
+     * @param integer $index
+     *
      * @return string[]
      */
-    public abstract function joinClauses(Mapper $left);
+    public abstract function joinClauses($name, $index);
 
-    protected function joinClause($tableFrom, $columnFrom, $tableTo, $columnTo)
+    protected function joinClause($tableFrom, $columnFrom, $tableTo, $columnTo, $aliasTo = null)
     {
-        return " inner join `{$tableTo}` on `{$tableFrom}`.`{$columnFrom}` = `{$tableTo}`.`{$columnTo}`";
+        $alias = $aliasTo ? "`{$aliasTo}`" : '';
+        return " inner join `{$tableTo}` {$alias} on `{$tableFrom}`.`{$columnFrom}` = `{$aliasTo}`.`{$columnTo}`";
     }
 
     /**

--- a/src/Bitmap/Association.php
+++ b/src/Bitmap/Association.php
@@ -5,13 +5,13 @@ namespace Bitmap;
 abstract class Association
 {
     protected $name;
-    protected $mapper;
+    protected $class;
     protected $right;
 
-    public function __construct($name, Mapper $mapper, $right)
+    public function __construct($name, $class, $right)
     {
         $this->name = $name;
-        $this->mapper = $mapper;
+        $this->class = $class;
         $this->right = $right;
     }
 
@@ -24,11 +24,19 @@ abstract class Association
     }
 
     /**
+     * @return mixed
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    /**
      * @return Mapper
      */
     public function getMapper()
     {
-        return $this->mapper;
+        return Bitmap::getMapper($this->class);
     }
 
     /**

--- a/src/Bitmap/Association.php
+++ b/src/Bitmap/Association.php
@@ -2,6 +2,8 @@
 
 namespace Bitmap;
 
+use Bitmap\Query\Context\Context;
+
 abstract class Association
 {
     protected $name;
@@ -50,16 +52,16 @@ abstract class Association
      * Return the list of join clauses from the class managed by the mapper $left
      *
      * @param string $name
-     * @param integer $index
+     * @param integer $depth
      *
      * @return string[]
      */
-    public abstract function joinClauses($name, $index);
+    public abstract function joinClauses($name, $depth);
 
     protected function joinClause($tableFrom, $columnFrom, $tableTo, $columnTo, $aliasTo = null)
     {
-        $alias = $aliasTo ? "`{$aliasTo}`" : '';
-        return " inner join `{$tableTo}` {$alias} on `{$tableFrom}`.`{$columnFrom}` = `{$aliasTo}`.`{$columnTo}`";
+        $alias = $aliasTo ? : $tableTo;
+        return " inner join `{$tableTo}` {$alias} on `{$tableFrom}`.`{$columnFrom}` = `{$alias}`.`{$columnTo}`";
     }
 
     /**
@@ -84,5 +86,5 @@ abstract class Association
      */
     public abstract function getAll(Entity $entity);
 
-    public abstract function set(ResultSet $result, Entity $entity, $with = [], $depth = 0);
+    public abstract function set(ResultSet $result, Entity $entity, Context $context, $depth = 0);
 }

--- a/src/Bitmap/Association.php
+++ b/src/Bitmap/Association.php
@@ -84,5 +84,5 @@ abstract class Association
      */
     public abstract function getAll(Entity $entity);
 
-    public abstract function set(ResultSet $result, Entity $entity);
+    public abstract function set(ResultSet $result, Entity $entity, $with = [], $depth = 0);
 }

--- a/src/Bitmap/AssociationManyToMany.php
+++ b/src/Bitmap/AssociationManyToMany.php
@@ -51,7 +51,7 @@ abstract class AssociationManyToMany extends Association
      */
     protected abstract function getEntities(Entity $entity);
 
-    public function set(ResultSet $result, Entity $entity)
+    public function set(ResultSet $result, Entity $entity, $with = [], $depth = 0)
     {
         $this->setEntities($entity, $this->getMapper()->loadAll($result));
     }

--- a/src/Bitmap/AssociationManyToMany.php
+++ b/src/Bitmap/AssociationManyToMany.php
@@ -8,19 +8,19 @@ abstract class AssociationManyToMany extends Association
     protected $leftReference;
     protected $rightReference;
     
-    public function __construct($name, Mapper $mapper, $right, $through, $leftReference, $rightReference)
+    public function __construct($name, $class, $right, $through, $leftReference, $rightReference)
     {
-        parent::__construct($name, $mapper, $right);
+        parent::__construct($name, $class, $right);
         $this->through = $through;
         $this->leftReference = $leftReference;
         $this->rightReference = $rightReference;
     }
 
-    public function joinClauses(Mapper $left)
+    public function joinClauses($name)
     {
         return [
-            $this->joinClause($left->getTable(), $this->name, $this->through, $this->leftReference),
-            $this->joinClause($this->through, $this->rightReference, $this->mapper->getTable(), $this->right)
+            $this->joinClause($name, $this->name, $this->through, $this->leftReference),
+            $this->joinClause($this->through, $this->rightReference, $this->getMapper()->getTable(), $this->right)
         ];
     }
 
@@ -53,7 +53,7 @@ abstract class AssociationManyToMany extends Association
 
     public function set(ResultSet $result, Entity $entity)
     {
-        $this->setEntities($entity, $this->mapper->loadAll($result));
+        $this->setEntities($entity, $this->getMapper()->loadAll($result));
     }
 
     /**

--- a/src/Bitmap/AssociationManyToMany.php
+++ b/src/Bitmap/AssociationManyToMany.php
@@ -2,6 +2,8 @@
 
 namespace Bitmap;
 
+use Bitmap\Query\Context\Context;
+
 abstract class AssociationManyToMany extends Association
 {
     protected $through;
@@ -16,7 +18,7 @@ abstract class AssociationManyToMany extends Association
         $this->rightReference = $rightReference;
     }
 
-    public function joinClauses($name)
+    public function joinClauses($name, $depth)
     {
         return [
             $this->joinClause($name, $this->name, $this->through, $this->leftReference),
@@ -51,7 +53,7 @@ abstract class AssociationManyToMany extends Association
      */
     protected abstract function getEntities(Entity $entity);
 
-    public function set(ResultSet $result, Entity $entity, $with = [], $depth = 0)
+    public function set(ResultSet $result, Entity $entity, Context $context, $depth = 0)
     {
         $this->setEntities($entity, $this->getMapper()->loadAll($result));
     }

--- a/src/Bitmap/AssociationOne.php
+++ b/src/Bitmap/AssociationOne.php
@@ -7,7 +7,7 @@ abstract class AssociationOne extends Association
     public function joinClauses(Mapper $left)
     {
         return [
-            $this->joinClause($left->getTable(), $this->name, $this->mapper->getTable(), $this->right)
+            $this->joinClause($left->getTable(), $this->name, $this->getMapper()->getTable(), $this->right)
         ];
     }
 
@@ -38,7 +38,7 @@ abstract class AssociationOne extends Association
 
     public function set(ResultSet $result, Entity $entity)
     {
-        $this->setEntity($entity, $this->mapper->loadOne($result));
+        $this->setEntity($entity, $this->getMapper()->loadOne($result));
     }
 
     protected abstract function setEntity(Entity $entity, Entity $associated);

--- a/src/Bitmap/AssociationOne.php
+++ b/src/Bitmap/AssociationOne.php
@@ -36,9 +36,9 @@ abstract class AssociationOne extends Association
      */
     protected abstract function getEntity(Entity $entity);
 
-    public function set(ResultSet $result, Entity $entity)
+    public function set(ResultSet $result, Entity $entity, $with = [], $depth = 0)
     {
-        $this->setEntity($entity, $this->getMapper()->loadOne($result));
+        $this->setEntity($entity, $this->getMapper()->loadOne($result, $with, $depth));
     }
 
     protected abstract function setEntity(Entity $entity, Entity $associated);

--- a/src/Bitmap/AssociationOne.php
+++ b/src/Bitmap/AssociationOne.php
@@ -4,10 +4,10 @@ namespace Bitmap;
 
 abstract class AssociationOne extends Association
 {
-    public function joinClauses(Mapper $left)
+    public function joinClauses($name, $index)
     {
         return [
-            $this->joinClause($left->getTable(), $this->name, $this->getMapper()->getTable(), $this->right)
+            $this->joinClause($name, $this->name, $this->getMapper()->getTable(), $this->right, $index > 0 ? $this->getMapper()->getTable() . $index : '')
         ];
     }
 

--- a/src/Bitmap/AssociationOne.php
+++ b/src/Bitmap/AssociationOne.php
@@ -2,12 +2,14 @@
 
 namespace Bitmap;
 
+use Bitmap\Query\Context\Context;
+
 abstract class AssociationOne extends Association
 {
-    public function joinClauses($name, $index)
+    public function joinClauses($name, $depth)
     {
         return [
-            $this->joinClause($name, $this->name, $this->getMapper()->getTable(), $this->right, $index > 0 ? $this->getMapper()->getTable() . $index : '')
+            $this->joinClause($name, $this->name, $this->getMapper()->getTable(), $this->right, $this->getMapper()->getTable() . ($depth > 0 ?  $depth : ''))
         ];
     }
 
@@ -36,9 +38,9 @@ abstract class AssociationOne extends Association
      */
     protected abstract function getEntity(Entity $entity);
 
-    public function set(ResultSet $result, Entity $entity, $with = [], $depth = 0)
+    public function set(ResultSet $result, Entity $entity, Context $context, $depth = 0)
     {
-        $this->setEntity($entity, $this->getMapper()->loadOne($result, $with, $depth));
+        $this->setEntity($entity, $this->getMapper()->loadOne($result, $context, $depth));
     }
 
     protected abstract function setEntity(Entity $entity, Entity $associated);

--- a/src/Bitmap/AssociationOneToMany.php
+++ b/src/Bitmap/AssociationOneToMany.php
@@ -4,10 +4,10 @@ namespace Bitmap;
 
 abstract class AssociationOneToMany extends Association
 {
-    public function joinClauses(Mapper $left)
+    public function joinClauses($name, $index)
     {
         return [
-            $this->joinClause($left->getTable(), $this->name, $this->getMapper()->getTable(), $this->right)
+            $this->joinClause($name, $this->name, $this->getMapper()->getTable(), $this->right)
         ];
     }
 
@@ -38,7 +38,7 @@ abstract class AssociationOneToMany extends Association
      */
     protected abstract function getEntities(Entity $entity);
 
-    public function set(ResultSet $result, Entity $entity)
+    public function set(ResultSet $result, Entity $entity, $with = [], $depth = 0)
     {
         $this->setEntities($entity, $this->getMapper()->loadAll($result));
     }

--- a/src/Bitmap/AssociationOneToMany.php
+++ b/src/Bitmap/AssociationOneToMany.php
@@ -7,7 +7,7 @@ abstract class AssociationOneToMany extends Association
     public function joinClauses(Mapper $left)
     {
         return [
-            $this->joinClause($left->getTable(), $this->name, $this->mapper->getTable(), $this->right)
+            $this->joinClause($left->getTable(), $this->name, $this->getMapper()->getTable(), $this->right)
         ];
     }
 
@@ -40,7 +40,7 @@ abstract class AssociationOneToMany extends Association
 
     public function set(ResultSet $result, Entity $entity)
     {
-        $this->setEntities($entity, $this->mapper->loadAll($result));
+        $this->setEntities($entity, $this->getMapper()->loadAll($result));
     }
 
     /**

--- a/src/Bitmap/AssociationOneToMany.php
+++ b/src/Bitmap/AssociationOneToMany.php
@@ -2,9 +2,11 @@
 
 namespace Bitmap;
 
+use Bitmap\Query\Context\Context;
+
 abstract class AssociationOneToMany extends Association
 {
-    public function joinClauses($name, $index)
+    public function joinClauses($name, $depth)
     {
         return [
             $this->joinClause($name, $this->name, $this->getMapper()->getTable(), $this->right)
@@ -38,9 +40,9 @@ abstract class AssociationOneToMany extends Association
      */
     protected abstract function getEntities(Entity $entity);
 
-    public function set(ResultSet $result, Entity $entity, $with = [], $depth = 0)
+    public function set(ResultSet $result, Entity $entity, Context $context, $depth = 0)
     {
-        $this->setEntities($entity, $this->getMapper()->loadAll($result));
+        $this->setEntities($entity, $this->getMapper()->loadAll($result, $context, $depth));
     }
 
     /**

--- a/src/Bitmap/Associations/MethodAssociationManyToMany.php
+++ b/src/Bitmap/Associations/MethodAssociationManyToMany.php
@@ -15,9 +15,9 @@ class MethodAssociationManyToMany extends AssociationManyToMany
     protected $getter;
     protected $setter;
 
-    public function __construct($name, Mapper $mapper, ReflectionMethod $getter, ReflectionMethod $setter, $through, $sourceReference, $targetReference, $target)
+    public function __construct($name, $class, ReflectionMethod $getter, ReflectionMethod $setter, $through, $sourceReference, $targetReference, $target)
     {
-        parent::__construct($name, $mapper, $target, $through, $sourceReference, $targetReference);
+        parent::__construct($name, $class, $target, $through, $sourceReference, $targetReference);
         $this->getter = $getter;
         $this->setter = $setter;
     }
@@ -32,8 +32,8 @@ class MethodAssociationManyToMany extends AssociationManyToMany
         $this->setter->invoke($entity, $entities);
     }
 
-    public static function fromMethods($name, Mapper $mapper, ReflectionMethod $getter, ReflectionMethod $setter, $through, $sourceReference, $targetReference, $column = null)
+    public static function fromMethods($name, $class, ReflectionMethod $getter, ReflectionMethod $setter, $through, $sourceReference, $targetReference, $column = null)
     {
-        return new MethodAssociationManyToMany($name, $mapper, $getter, $setter, $through, $sourceReference, $targetReference, $column);
+        return new MethodAssociationManyToMany($name, $class, $getter, $setter, $through, $sourceReference, $targetReference, $column);
     }
 }

--- a/src/Bitmap/Associations/MethodAssociationOne.php
+++ b/src/Bitmap/Associations/MethodAssociationOne.php
@@ -14,9 +14,9 @@ class MethodAssociationOne extends AssociationOne
     protected $getter;
     protected $setter;
 
-    public function __construct($name, Mapper $mapper, ReflectionMethod $getter, ReflectionMethod $setter, $target)
+    public function __construct($name, $class, ReflectionMethod $getter, ReflectionMethod $setter, $target)
     {
-        parent::__construct($name, $mapper, $target);
+        parent::__construct($name, $class, $target);
         $this->getter = $getter;
         $this->setter = $setter;
     }
@@ -31,8 +31,8 @@ class MethodAssociationOne extends AssociationOne
         $this->setter->invoke($entity, $associated);
     }
 
-    public static function fromMethods($name, Mapper $mapper, ReflectionMethod $getter, ReflectionMethod $setter, $column = null)
+    public static function fromMethods($name, $class, ReflectionMethod $getter, ReflectionMethod $setter, $column = null)
     {
-        return new MethodAssociationOne($name, $mapper, $getter, $setter, $column);
+        return new MethodAssociationOne($name, $class, $getter, $setter, $column);
     }
 }

--- a/src/Bitmap/Associations/MethodAssociationOneToMany.php
+++ b/src/Bitmap/Associations/MethodAssociationOneToMany.php
@@ -14,9 +14,9 @@ class MethodAssociationOneToMany extends AssociationOneToMany
     protected $getter;
     protected $setter;
 
-    public function __construct($name, Mapper $mapper, ReflectionMethod $getter, ReflectionMethod $setter, $target)
+    public function __construct($name, $class, ReflectionMethod $getter, ReflectionMethod $setter, $target)
     {
-        parent::__construct($name, $mapper, $target);
+        parent::__construct($name, $class, $target);
         $this->getter = $getter;
         $this->setter = $setter;
     }
@@ -31,8 +31,8 @@ class MethodAssociationOneToMany extends AssociationOneToMany
         $this->setter->invoke($entity, $entities);
     }
 
-    public static function fromMethods($name, Mapper $mapper, ReflectionMethod $getter, ReflectionMethod $setter, $column = null)
+    public static function fromMethods($name, $class, ReflectionMethod $getter, ReflectionMethod $setter, $column = null)
     {
-        return new MethodAssociationOneToMany($name, $mapper, $getter, $setter, $column);
+        return new MethodAssociationOneToMany($name, $class, $getter, $setter, $column);
     }
 }

--- a/src/Bitmap/Associations/PropertyAssociationOne.php
+++ b/src/Bitmap/Associations/PropertyAssociationOne.php
@@ -12,9 +12,9 @@ class PropertyAssociationOne extends AssociationOne
 {
     protected $property;
 
-    public function __construct($name, Mapper $mapper, ReflectionProperty $property, $target)
+    public function __construct($name, $class, ReflectionProperty $property, $target)
     {
-        parent::__construct($name, $mapper, $target);
+        parent::__construct($name, $class, $target);
         $this->property = $property;
     }
 

--- a/src/Bitmap/Bitmap.php
+++ b/src/Bitmap/Bitmap.php
@@ -2,20 +2,13 @@
 
 namespace Bitmap;
 
-use Bitmap\Transformers\FloatTransformer;
-use Bitmap\Transformers\IntegerTransformer;
-use Bitmap\Transformers\StringTransformer;
 use PDO;
 use ReflectionClass;
+use Exception;
 
 /**
  * Class Bitmap
  * @package PierreLemee\Bitmap
- *
- * TODO:
- *  - ono-to-one association
- *  - many-to-one association
- *  - many-to-many
  */
 class Bitmap
 {
@@ -124,9 +117,20 @@ class Bitmap
      * @param string $class
      *
      * @return Mapper
+     *
+     * @throws Exception
      */
     public static function getMapper($class)
     {
+        if (!self::current()->hasMapper($class)) {
+            $entity = new ReflectionClass($class);
+            if ($entity->isSubclassOf(Entity::class)) {
+                self::current()->addMapper($entity->newInstance()->mapper());
+            } else {
+                throw new Exception(sprintf("'%s' must be a sub class of '%s'", $class, Entity::class));
+            }
+        }
+
         return self::current()->mappers[$class];
     }
 

--- a/src/Bitmap/Entity.php
+++ b/src/Bitmap/Entity.php
@@ -30,7 +30,7 @@ abstract class Entity
 	/**
 	 * @return Mapper
 	 */
-    protected function mapper()
+    public function mapper()
     {
     	if (null === $this->mapper) {
     		$this->mapper = $this->getMapper();
@@ -46,11 +46,6 @@ abstract class Entity
 
     public static function getClassMapper($class)
     {
-        if (!Bitmap::hasMapper($class)) {
-        	$entity = new $class();
-            Bitmap::addMapper($entity->mapper());
-        }
-
         return Bitmap::getMapper($class);
     }
 

--- a/src/Bitmap/FieldMappingStrategy.php
+++ b/src/Bitmap/FieldMappingStrategy.php
@@ -16,8 +16,9 @@ abstract class FieldMappingStrategy
     /**
      * @param Mapper $mapper
      * @param Field $field
+     * @param integer $index
      *
      * @return string
      */
-    public abstract function getFieldLabel(Mapper $mapper, Field $field);
+    public abstract function getFieldLabel(Mapper $mapper, Field $field, $index = 0);
 }

--- a/src/Bitmap/FieldMappingStrategy.php
+++ b/src/Bitmap/FieldMappingStrategy.php
@@ -16,9 +16,9 @@ abstract class FieldMappingStrategy
     /**
      * @param Mapper $mapper
      * @param Field $field
-     * @param integer $index
+     * @param integer $depth
      *
      * @return string
      */
-    public abstract function getFieldLabel(Mapper $mapper, Field $field, $index = 0);
+    public abstract function getFieldLabel(Mapper $mapper, Field $field, $depth = 0);
 }

--- a/src/Bitmap/Mapper.php
+++ b/src/Bitmap/Mapper.php
@@ -280,7 +280,9 @@ class Mapper
 		    }
 
 		    foreach ($this->associations as $association) {
-			    $association->set($result, $entity);
+                if ($association->getClass() !== $this->class) {
+                    $association->set($result, $entity);
+                }
 		    }
 
 		    $entity->setBitmapHash($this->hash($entity));

--- a/src/Bitmap/Mapper.php
+++ b/src/Bitmap/Mapper.php
@@ -271,9 +271,9 @@ class Mapper
      *
      * @return Entity
      */
-    public function loadOne(ResultSet $result, $with = null, $ranks = null)
+    public function loadOne(ResultSet $result, $with = null, $depth = 0)
     {
-    	if (sizeof($values = $result->getValuesOneEntity($this)) > 0) {
+    	if (sizeof($values = $result->getValuesOneEntity($this, $depth)) > 0) {
 		    $entity = $this->createEntity();
 		    foreach ($values as $name => $value) {
 			    $this->fieldsByName[$name]->set($entity, $value);
@@ -281,9 +281,7 @@ class Mapper
 
 		    foreach ($this->associations as $association) {
                 if (null === $with || (is_array($with) && isset($with[$association->getName()]))) {
-                    if ($association->getClass() !== $this->class) {
-                        $association->set($result, $entity);
-                    }
+                    $association->set($result, $entity, is_array($with[$association->getName()]) ? $with[$association->getName()] : [], $depth + 1);
                 }
 		    }
 

--- a/src/Bitmap/Mapper.php
+++ b/src/Bitmap/Mapper.php
@@ -271,7 +271,7 @@ class Mapper
      *
      * @return Entity
      */
-    public function loadOne(ResultSet $result)
+    public function loadOne(ResultSet $result, $with = null, $ranks = null)
     {
     	if (sizeof($values = $result->getValuesOneEntity($this)) > 0) {
 		    $entity = $this->createEntity();
@@ -280,8 +280,10 @@ class Mapper
 		    }
 
 		    foreach ($this->associations as $association) {
-                if ($association->getClass() !== $this->class) {
-                    $association->set($result, $entity);
+                if (null === $with || (is_array($with) && isset($with[$association->getName()]))) {
+                    if ($association->getClass() !== $this->class) {
+                        $association->set($result, $entity);
+                    }
                 }
 		    }
 

--- a/src/Bitmap/Query/Context/Context.php
+++ b/src/Bitmap/Query/Context/Context.php
@@ -7,14 +7,33 @@ use Bitmap\Mapper;
 class Context
 {
     protected $dependencies;
+    /**
+     * @var Context
+     */
+    protected $parent;
 
-    public function __construct($with = null)
+    public function __construct($with = null, $parent = null)
     {
         $this->dependencies = [];
+        $this->parent = $parent;
 
         if ($with) {
             $this->addDependency($with);
         }
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return int
+     */
+    public function getDepth($name)
+    {
+        if (null !== $this->parent) {
+            return $this->parent->hasDependency($name) ? 1 + $this->parent->getDepth($name): 0;
+        }
+
+        return 0;
     }
 
     public function addDependency($with, $sub = null)
@@ -24,9 +43,9 @@ class Context
                 $this->addDependency($key, $value);
             }
         } else if (is_int($with)) {
-            $this->dependencies[$sub] = new Context();
+            $this->dependencies[$sub] = new Context(null, $this);
         } else {
-            $this->dependencies[$with] = new Context($sub);
+            $this->dependencies[$with] = new Context($sub, $this);
         }
     }
 
@@ -40,17 +59,17 @@ class Context
         return isset($this->dependencies[$name]) ? $this->dependencies[$name] : new Context();
     }
 
-    public static function fromContext($context)
+    public static function fromContext($context, $parent = null)
     {
         if (null !== $context && $context instanceof Context) {
             return $context;
         }
 
-        return new Context($context);
+        return new Context($context, $parent);
     }
 
-    public static function fromMapper(Mapper $mapper)
+    public static function fromMapper(Mapper $mapper, $parent = null)
     {
-        return new Context(array_keys($mapper->associations()));
+        return new Context(array_keys($mapper->associations()), $parent);
     }
 }

--- a/src/Bitmap/Query/Select.php
+++ b/src/Bitmap/Query/Select.php
@@ -100,10 +100,15 @@ class Select extends Query
         $joins = [];
         $mapper = $mapper ? : $this->mapper;
         foreach ($mapper->associations() as $association) {
-            $joins = array_merge($joins, $association->joinClauses($mapper));
+            if ($association->getClass() !== $mapper->getClass()) {
+                $joins = array_merge($joins, $association->joinClauses($mapper));
+            }
         }
         foreach ($mapper->associations() as $association) {
-            $joins = array_merge($joins, $this->joinClauses($association->getMapper()));
+            if ($association->getClass() !== $mapper->getClass()) {
+                $joins = array_merge($joins, $this->joinClauses($association->getMapper()));
+            }
+
         }
 
         return $joins;
@@ -123,7 +128,9 @@ class Select extends Query
         }
 
         foreach ($mapper->associations() as $association) {
-            $fields = array_merge($fields, $this->fields($association->getMapper()));
+            if ($this->mapper->getClass() !== $mapper->getClass()) {
+                $fields = array_merge($fields, $this->fields($association->getMapper()));
+            }
         }
 
         return $fields;

--- a/src/Bitmap/Query/Select.php
+++ b/src/Bitmap/Query/Select.php
@@ -106,7 +106,6 @@ class Select extends Query
 	    throw new Exception("No field with name '{$field}'");
     }
 
-    protected function joinClauses($mapper = null)
     /**
      * @param $mapper Mapper
      * @param $with array

--- a/src/Bitmap/Query/Select.php
+++ b/src/Bitmap/Query/Select.php
@@ -37,7 +37,6 @@ class Select extends Query
     public function execute(PDO $connection)
     {
         $sql = $this->sql();
-        echo "$sql\n";
         return $connection->query($sql, $this->strategy->getPdoFetchingType());
     }
 
@@ -51,7 +50,7 @@ class Select extends Query
     {
         $this->with = $with;
         $stmt = $this->execute(Bitmap::connection($connection));
-        $result = new ResultSet($stmt, $this->mapper, $this->strategy);
+        $result = new ResultSet($stmt, $this->mapper, $this->strategy, $with);
 
         return $this->mapper->loadOne($result);
     }

--- a/src/Bitmap/ResultSet.php
+++ b/src/Bitmap/ResultSet.php
@@ -2,8 +2,8 @@
 
 namespace Bitmap;
 
+use Bitmap\Query\Context\Context;
 use PDOStatement;
-use PDO;
 
 class ResultSet
 {
@@ -12,25 +12,25 @@ class ResultSet
      */
     protected $values;
 
-    public function __construct(PDOStatement $statement, Mapper $mapper, FieldMappingStrategy $strategy, $with = [])
+    public function __construct(PDOStatement $statement, Mapper $mapper, FieldMappingStrategy $strategy, Context $context)
     {
         $this->values = [];
 
         // Should ask to a Strategy for the fetch mode
         while (false !== $data = $statement->fetch($strategy->getPdoFetchingType())) {
-            $this->read($mapper, $data, $strategy, $with);
+            $this->read($mapper, $data, $strategy, $context);
         }
     }
 
-    protected function value(Mapper $mapper, Field $field, array $data, FieldMappingStrategy $strategy, $index = 0)
+    protected function value(Mapper $mapper, Field $field, array $data, FieldMappingStrategy $strategy, $depth = 0)
     {
-        if (($key = $strategy->getFieldLabel($mapper, $field, $index)) !== null && isset($data[$key])) {
+        if (($key = $strategy->getFieldLabel($mapper, $field, $depth)) !== null && isset($data[$key])) {
             return $data[$key];
         }
         return null;
     }
 
-    protected function read(Mapper $mapper, array $data, FieldMappingStrategy $strategy, $with = [], $depth = 0)
+    protected function read(Mapper $mapper, array $data, FieldMappingStrategy $strategy, Context $context, $depth = 0)
     {
         $primary = $this->value($mapper, $mapper->getPrimary(), $data, $strategy, $depth);
 
@@ -42,8 +42,8 @@ class ResultSet
         }
 
         foreach ($mapper->associations() as $name => $association) {
-            if (isset($with[$association->getName()])) {
-                $this->read($association->getMapper(), $data, $strategy, is_array($with[$association->getName()]) ? $with[$association->getName()] : [], $depth + 1);
+            if ($context->hasDependency($association->getName())) {
+                $this->read($association->getMapper(), $data, $strategy, $context->getDependency($association->getName()), $depth + ($mapper->getClass() === $association->getMapper() ? 1 : 0));
             }
         }
     }
@@ -53,6 +53,7 @@ class ResultSet
         if (isset($this->values[$mapper->getClass()][$depth]) && sizeof($this->values[$mapper->getClass()][$depth]) > 0) {
             return array_values($this->values[$mapper->getClass()][$depth])[0];
         }
+
         return [];
     }
 
@@ -61,6 +62,7 @@ class ResultSet
         if (isset($this->values[$mapper->getClass()][$depth])) {
             return array_values($this->values[$mapper->getClass()][$depth]);
         }
+
         return [];
     }
 

--- a/src/Bitmap/ResultSet.php
+++ b/src/Bitmap/ResultSet.php
@@ -12,54 +12,54 @@ class ResultSet
      */
     protected $values;
 
-    public function __construct(PDOStatement $statement, Mapper $mapper, FieldMappingStrategy $strategy)
+    public function __construct(PDOStatement $statement, Mapper $mapper, FieldMappingStrategy $strategy, $with = [])
     {
         $this->values = [];
 
         // Should ask to a Strategy for the fetch mode
         while (false !== $data = $statement->fetch($strategy->getPdoFetchingType())) {
-            $this->read($mapper, $data, $strategy);
+            $this->read($mapper, $data, $strategy, $with);
         }
     }
 
-    protected function value(Mapper $mapper, Field $field, array $data, FieldMappingStrategy $strategy)
+    protected function value(Mapper $mapper, Field $field, array $data, FieldMappingStrategy $strategy, $index = 0)
     {
-        if (($key = $strategy->getFieldLabel($mapper, $field)) !== null && isset($data[$key])) {
+        if (($key = $strategy->getFieldLabel($mapper, $field, $index)) !== null && isset($data[$key])) {
             return $data[$key];
         }
         return null;
     }
 
-    protected function read(Mapper $mapper, array $data, FieldMappingStrategy $strategy)
+    protected function read(Mapper $mapper, array $data, FieldMappingStrategy $strategy, $with = [], $depth = 0)
     {
-        $primary = $this->value($mapper, $mapper->getPrimary(), $data, $strategy);
+        $primary = $this->value($mapper, $mapper->getPrimary(), $data, $strategy, $depth);
 
         if (null !== $primary && !isset($this->values[$mapper->getClass()][$mapper->getPrimary()->getName()])) {
-            $this->values[$mapper->getClass()][$primary] = [];
+            $this->values[$mapper->getClass()][$depth][$primary] = [];
             foreach ($mapper->getFields() as $name => $field) {
-                $this->values[$mapper->getClass()][$primary][$field->getName()] = $this->value($mapper, $field, $data, $strategy);
+                $this->values[$mapper->getClass()][$depth][$primary][$field->getName()] = $this->value($mapper, $field, $data, $strategy, $depth);
             }
         }
 
         foreach ($mapper->associations() as $name => $association) {
-            if ($association->getClass() !== $mapper->getClass()) {
-                $this->read($association->getMapper(), $data, $strategy);
+            if (isset($with[$association->getName()])) {
+                $this->read($association->getMapper(), $data, $strategy, is_array($with[$association->getName()]) ? $with[$association->getName()] : [], $depth + 1);
             }
         }
     }
 
-    public function getValuesOneEntity(Mapper $mapper)
+    public function getValuesOneEntity(Mapper $mapper, $depth = 0)
     {
-        if (isset($this->values[$mapper->getClass()]) && sizeof($this->values[$mapper->getClass()]) > 0) {
-            return array_values($this->values[$mapper->getClass()])[0];
+        if (isset($this->values[$mapper->getClass()][$depth]) && sizeof($this->values[$mapper->getClass()][$depth]) > 0) {
+            return array_values($this->values[$mapper->getClass()][$depth])[0];
         }
         return [];
     }
 
-    public function getValuesAllEntity(Mapper $mapper)
+    public function getValuesAllEntity(Mapper $mapper, $depth = 0)
     {
-        if (isset($this->values[$mapper->getClass()])) {
-            return array_values($this->values[$mapper->getClass()]);
+        if (isset($this->values[$mapper->getClass()][$depth])) {
+            return array_values($this->values[$mapper->getClass()][$depth]);
         }
         return [];
     }

--- a/src/Bitmap/ResultSet.php
+++ b/src/Bitmap/ResultSet.php
@@ -42,7 +42,9 @@ class ResultSet
         }
 
         foreach ($mapper->associations() as $name => $association) {
-            $this->read($association->getMapper(), $data, $strategy);
+            if ($association->getClass() !== $mapper->getClass()) {
+                $this->read($association->getMapper(), $data, $strategy);
+            }
         }
     }
 

--- a/src/Bitmap/Strategies/GroupStrategy.php
+++ b/src/Bitmap/Strategies/GroupStrategy.php
@@ -45,7 +45,7 @@ class GroupStrategy extends FieldMappingStrategy
         }
     }
 
-    public function getFieldLabel(Mapper $mapper, Field $field)
+    public function getFieldLabel(Mapper $mapper, Field $field, $index = 0)
     {
         return isset($this->mapping[$mapper->getTable()][$field->getName()]) ? $this->mapping[$mapper->getTable()][$field->getName()] : null;
     }

--- a/src/Bitmap/Strategies/PrefixStrategy.php
+++ b/src/Bitmap/Strategies/PrefixStrategy.php
@@ -14,8 +14,9 @@ class PrefixStrategy extends FieldMappingStrategy
         return PDO::FETCH_ASSOC;
     }
 
-    public function getFieldLabel(Mapper $mapper, Field $field)
+    public function getFieldLabel(Mapper $mapper, Field $field, $index = 0)
     {
-        return "{$mapper->getTable()}.{$field->getName()}";
+        $suffix = $index > 0 ? $index : '';
+        return "{$mapper->getTable()}{$suffix}.{$field->getName()}";
     }
 }

--- a/src/Bitmap/Strategies/PrefixStrategy.php
+++ b/src/Bitmap/Strategies/PrefixStrategy.php
@@ -14,9 +14,9 @@ class PrefixStrategy extends FieldMappingStrategy
         return PDO::FETCH_ASSOC;
     }
 
-    public function getFieldLabel(Mapper $mapper, Field $field, $index = 0)
+    public function getFieldLabel(Mapper $mapper, Field $field, $depth = 0)
     {
-        $suffix = $index > 0 ? $index : '';
+        $suffix = $depth > 0 ? $depth : '';
         return "{$mapper->getTable()}{$suffix}.{$field->getName()}";
     }
 }

--- a/tests/Bitmap/EntityTest.php
+++ b/tests/Bitmap/EntityTest.php
@@ -2,6 +2,7 @@
 
 namespace Bitmap;
 
+use Chinook\Valid\Inline\Employee;
 use Chinook\Valid\Inline\Album;
 use Chinook\Valid\Inline\Artist;
 use Chinook\Valid\Inline\Track;
@@ -29,6 +30,15 @@ class EntityTest extends TestCase
     public function after()
     {
         Bitmap::connection(self::CONNECTION_NAME)->rollBack();
+    }
+
+    public function testGetEmployeeAndSuperior()
+    {
+        $employee= Employee::select()->where('EmployeeId', '=', 8)->one();
+
+        $this->assertNotNull($employee);
+        $this->assertNotNull($employee->getSuperior());
+        $this->assertEquals(Employee::class, get_class($employee->getSuperior()));
     }
 
     public function testAddNewArtist()

--- a/tests/Bitmap/EntityTest.php
+++ b/tests/Bitmap/EntityTest.php
@@ -32,15 +32,6 @@ class EntityTest extends TestCase
         Bitmap::connection(self::CONNECTION_NAME)->rollBack();
     }
 
-    public function testGetEmployeeAndSuperior()
-    {
-        $employee= Employee::select()->where('EmployeeId', '=', 8)->one();
-
-        $this->assertNotNull($employee);
-        $this->assertNotNull($employee->getSuperior());
-        $this->assertEquals(Employee::class, get_class($employee->getSuperior()));
-    }
-
     public function testAddNewArtist()
     {
         $artist = new Artist();

--- a/tests/Bitmap/SelectTest.php
+++ b/tests/Bitmap/SelectTest.php
@@ -2,9 +2,9 @@
 
 namespace Bitmap;
 
-
 use Chinook\Valid\Inline\Album;
 use Chinook\Valid\Inline\Artist;
+use Chinook\Valid\Inline\Employee;
 use PHPUnit\Framework\TestCase;
 
 class SelectTest extends TestCase
@@ -112,6 +112,15 @@ class SelectTest extends TestCase
         $this->assertNotNull($album);
         $this->assertSame('Vivaldi: The Four Seasons', $album->getTitle());
         $this->assertSame(209, $album->getArtist()->getId());
+    }
+
+    public function testGetEmployeeAndSuperior()
+    {
+        $employee= Employee::select()->where('EmployeeId', '=', 8)->one();
+
+        $this->assertNotNull($employee);
+        $this->assertNotNull($employee->getSuperior());
+        $this->assertEquals(Employee::class, get_class($employee->getSuperior()));
     }
 
 }

--- a/tests/Bitmap/models/Chinook/Valid/Inline/Album.php
+++ b/tests/Bitmap/models/Chinook/Valid/Inline/Album.php
@@ -36,10 +36,10 @@ class Album extends Entity
                     ->setType(Bitmap::TYPE_STRING)
             )
             ->addAssociation(
-                MethodAssociationOne::fromMethods('ArtistId', self::getClassMapper('Chinook\Valid\Inline\Artist'), $reflection->getMethod('getArtist'), $reflection->getMethod('setArtist'), 'ArtistId')
+                MethodAssociationOne::fromMethods('ArtistId', Artist::class, $reflection->getMethod('getArtist'), $reflection->getMethod('setArtist'), 'ArtistId')
             )
             ->addAssociation(
-                MethodAssociationOneToMany::fromMethods('AlbumId', self::getClassMapper('Chinook\Valid\Inline\Track'), $reflection->getMethod('getTracks'), $reflection->getMethod('setTracks'), 'AlbumId')
+                MethodAssociationOneToMany::fromMethods('AlbumId', Track::class, $reflection->getMethod('getTracks'), $reflection->getMethod('setTracks'), 'AlbumId')
             );
     }
 

--- a/tests/Bitmap/models/Chinook/Valid/Inline/Employee.php
+++ b/tests/Bitmap/models/Chinook/Valid/Inline/Employee.php
@@ -33,7 +33,7 @@ class Employee extends Entity
             ->addAssociation(
                 MethodAssociationOne::fromMethods(
                     'ReportsTo',
-                    __CLASS__,
+                    Employee::class,
                     $reflection->getMethod('getSuperior'),
                     $reflection->getMethod('setSuperior'),
                     'EmployeeId'

--- a/tests/Bitmap/models/Chinook/Valid/Inline/Employee.php
+++ b/tests/Bitmap/models/Chinook/Valid/Inline/Employee.php
@@ -33,7 +33,7 @@ class Employee extends Entity
             ->addAssociation(
                 MethodAssociationOne::fromMethods(
                     'ReportsTo',
-                    self::mapper(),
+                    __CLASS__,
                     $reflection->getMethod('getSuperior'),
                     $reflection->getMethod('setSuperior'),
                     'EmployeeId'

--- a/tests/Bitmap/models/Chinook/Valid/Inline/Employee.php
+++ b/tests/Bitmap/models/Chinook/Valid/Inline/Employee.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Chinook\Valid\Inline;
+
+use Bitmap\Associations\MethodAssociationOne;
+use Bitmap\Bitmap;
+use Bitmap\Entity;
+use Bitmap\Fields\MethodField;
+use Bitmap\Mapper;
+use ReflectionClass;
+
+class Employee extends Entity
+{
+    protected $id;
+    /**
+     * @var Employee
+     */
+    protected $superior;
+    protected $firstname;
+    protected $lastname;
+    protected $title;
+    protected $bornAt;
+    protected $hiredAt;
+
+    public function getMapper()
+    {
+        $reflection = new ReflectionClass(__CLASS__);
+        return Mapper::of(__CLASS__)
+            ->addPrimary(
+                MethodField::fromClass('EmployeeId', $reflection, 'id')
+                ->setType(Bitmap::TYPE_INTEGER)
+            )
+            ->addAssociation(
+                MethodAssociationOne::fromMethods(
+                    'ReportsTo',
+                    self::mapper(),
+                    $reflection->getMethod('getSuperior'),
+                    $reflection->getMethod('setSuperior'),
+                    'EmployeeId'
+                )
+            )
+            ->addField(
+                MethodField::fromClass('LastName', $reflection, 'lastname')
+                    ->setType(Bitmap::TYPE_STRING)
+            )
+            ->addField(
+                MethodField::fromClass('FirstName', $reflection, 'firstname')
+                    ->setType(Bitmap::TYPE_STRING)
+            )
+            ->addField(
+                MethodField::fromClass('BirthDate', $reflection, 'bornAt')
+                    ->setType(Bitmap::TYPE_DATETIME)
+            )
+            ->addField(
+                MethodField::fromClass('HireDate', $reflection, 'hiredAt')
+                    ->setType(Bitmap::TYPE_DATETIME)
+            );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param mixed $id
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return Employee
+     */
+    public function getSuperior()
+    {
+        return $this->superior;
+    }
+
+    /**
+     * @param Employee $superior
+     */
+    public function setSuperior($superior)
+    {
+        $this->superior = $superior;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFirstname()
+    {
+        return $this->firstname;
+    }
+
+    /**
+     * @param mixed $firstname
+     */
+    public function setFirstname($firstname)
+    {
+        $this->firstname = $firstname;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLastname()
+    {
+        return $this->lastname;
+    }
+
+    /**
+     * @param mixed $lastname
+     */
+    public function setLastname($lastname)
+    {
+        $this->lastname = $lastname;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param mixed $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBornAt()
+    {
+        return $this->bornAt;
+    }
+
+    /**
+     * @param mixed $bornAt
+     */
+    public function setBornAt($bornAt)
+    {
+        $this->bornAt = $bornAt;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getHiredAt()
+    {
+        return $this->hiredAt;
+    }
+
+    /**
+     * @param mixed $hiredAt
+     */
+    public function setHiredAt($hiredAt)
+    {
+        $this->hiredAt = $hiredAt;
+    }
+}

--- a/tests/Bitmap/models/Chinook/Valid/Inline/Playlist.php
+++ b/tests/Bitmap/models/Chinook/Valid/Inline/Playlist.php
@@ -35,7 +35,7 @@ class Playlist extends Entity
             ->addAssociation(
                 MethodAssociationManyToMany::fromMethods(
                     'PlaylistId',
-                    self::getClassMapper('Chinook\Valid\Inline\Track'),
+                    Track::class,
                     $reflection->getMethod('getTracks'),
                     $reflection->getMethod('setTracks'),
                     'PlaylistTrack',

--- a/tests/Bitmap/models/Chinook/Valid/Inline/Track.php
+++ b/tests/Bitmap/models/Chinook/Valid/Inline/Track.php
@@ -51,10 +51,10 @@ class Track extends Entity
                     ->setTransformer(Bitmap::getTransformer(Bitmap::TYPE_FLOAT))
             )
             ->addAssociation(
-                MethodAssociationOne::fromMethods('GenreId', self::getClassMapper('Chinook\Valid\Inline\Genre'), $reflection->getMethod('getGenre'), $reflection->getMethod('setGenre'), 'GenreId')
+                MethodAssociationOne::fromMethods('GenreId', Genre::class, $reflection->getMethod('getGenre'), $reflection->getMethod('setGenre'), 'GenreId')
             )
             ->addAssociation(
-                MethodAssociationOne::fromMethods('MediaTypeId', self::getClassMapper('Chinook\Valid\Inline\MediaType'), $reflection->getMethod('getMedia'), $reflection->getMethod('setMedia'), 'MediaTypeId')
+                MethodAssociationOne::fromMethods('MediaTypeId', MediaType::class, $reflection->getMethod('getMedia'), $reflection->getMethod('setMedia'), 'MediaTypeId')
             );
     }
 


### PR DESCRIPTION
This problem is probably not a rare one and deserves to be taken care of wisely.

The `select() .. one()` reveals several problems:
- including the association one entity referring to itself might lead to a never ending SQL query (a join from A to A, itself joined to A and so on ...). Introducing depth (default value to `1`when not specified in the `$with` argument ?)
- at the moment we are prefixing each table by its name. But when joining a class to itself, this won't work anymore. We should add a counter on each class, and so when extracting entities from the `ResultSet`
- If we select a list of entities A, with a depth `n`, maybe we can find the associated entity in one of the entities in the range `[1 .. n-1]`